### PR TITLE
fix: Update model identification for Ember Mug 2 14oz

### DIFF
--- a/ember_mug/utils.py
+++ b/ember_mug/utils.py
@@ -97,11 +97,11 @@ def get_model_from_single_int_and_services(  # noqa PLR0911
         return DeviceModel.MUG_1_10_OZ
     if model_id == 65:
         return DeviceModel.MUG_1_14_OZ
-    if model_id in (-63, -61, -62):
+    if model_id in (-51, -63, -61, -62):
         return DeviceModel.MUG_2_14_OZ
     if model_id == -60:
         return DeviceModel.CUP_6_OZ
-    if model_id in (-127, -126, -125, -124, -123, -122, -120, -117, -57, -56, -55, -53, -52, -51, 83, 131):
+    if model_id in (-127, -126, -125, -124, -123, -122, -120, -117, -57, -56, -55, -53, -52, 83, 131):
         return DeviceModel.MUG_2_10_OZ
     return None
 


### PR DESCRIPTION
## Description
This PR fixes an issue where certain Ember Mug 2 14oz models are incorrectly identified as 10oz models. The problem occurs because this 14oz mug advertises with manufacturer data value `-51` which is currently associated with 10oz models in the code-base.

## Problem
My Ember Mug 2 14oz is incorrectly identified as a 10oz model because it advertises with manufacturer data `0xCD` (decimal: -51). The current code classifies this value as indicating a 10oz model. The only real issue this causes are incorrect fill level readings.

## Solution
This PR moves the manufacturer data value `-51` from the 10oz list to the 14oz list in the model identification logic.

## Additional Context
Unless, of course, the `-51` value has been definitively confirmed with a 10oz mug in another situation.